### PR TITLE
fix: stop overwriting index.yaml in action

### DIFF
--- a/.github/configs/cr.yaml
+++ b/.github/configs/cr.yaml
@@ -1,0 +1,6 @@
+## Reference: https://github.com/helm/chart-releaser
+index-path: "./index.yaml"
+
+# Enable automatic generation of release notes using GitHubs release notes generator.
+# see: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+generate-release-notes: true

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,5 +29,7 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          config: "./.github/configs/cr.yaml"
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR resolves the issue of the index being overwritten by the `helm-releaser-action`.

I've also restored the `index.yaml` manually in this [commit](https://github.com/argonautdev/charts/commit/c87fff7fe275e5ca40fe033b4e60d16d16ac9281) to the one generated at the `v0.6.8` release.

## Note

The current `index.yaml` doesn't point to the releases created by the action, but the ones generated using the script (which shouldn't cause any issues as long as the releases and the `dist` folder are in place).

On the next releases, it should automatically populate the index with the GitHub release URLs. **Don't delete the releases generated by the action.**